### PR TITLE
infra: switch to `uv` to build and publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,15 +15,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
-
-      - name: deps
-        run: python3 -m pip install -U build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
 
       - name: build
-        run: python3 -m build
+        run: uv build
 
       - name: publish
-        uses: pypa/gh-action-pypi-publish@release/v1
+        run: uv publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools>=61.0.0"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
 
 [project]
 name = "pytest-ty"


### PR DESCRIPTION
- **infra: switch to `uv` as build and publishing backend**

